### PR TITLE
Has title

### DIFF
--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -225,8 +225,12 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
           .executorMobile(executorMobile).content(envVars.expand(content).replaceAll("\\\\n", "\n"))
           .build()
           .toMarkdown();
-      MessageModel message = MessageModel.builder().type(MsgTypeEnum.ACTION_CARD).atAll(atAll)
-          .atMobiles(atMobiles).text(text).btns(btns).build();
+      MessageModel message = MessageModel.builder()
+              .type(MsgTypeEnum.ACTION_CARD)
+              .atAll(atAll)
+              .atMobiles(atMobiles)
+              .title(envVars.expand(projectName + " " + statusType.getLabel()))
+              .text(text).btns(btns).build();
 
       log(listener, "当前机器人信息，%s", Utils.toJson(item));
       log(listener, "发送的消息详情，%s", Utils.toJson(message));

--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -229,7 +229,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
               .type(MsgTypeEnum.ACTION_CARD)
               .atAll(atAll)
               .atMobiles(atMobiles)
-              .title(envVars.expand(projectName + " " + statusType.getLabel()))
+              .title(envVars.expand(job.getDisplayName() + " " + statusType.getLabel()))
               .text(text).btns(btns).build();
 
       log(listener, "当前机器人信息，%s", Utils.toJson(item));

--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -229,7 +229,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
               .type(MsgTypeEnum.ACTION_CARD)
               .atAll(atAll)
               .atMobiles(atMobiles)
-              .title(envVars.expand(job.getDisplayName() + " " + statusType.getLabel()))
+              .title(envVars.expand(job.getName() + " " + statusType.getLabel()))
               .text(text).btns(btns).build();
 
       log(listener, "当前机器人信息，%s", Utils.toJson(item));


### PR DESCRIPTION
普通任务通知时，将标题由“Jenkins 构建通知”改为 项目短名称+状态。方便手机直接在通知栏即可看到主要内容。
