### PR TITLE
fix: keep pipeline environment variables isolated between concurrent builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
       <version>1.18.46</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -61,7 +61,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
 			DingTalkUtils.log(listener, "发送消息时报错: %s", e);
 		} finally {
 			// 重置环境变量
-			PipelineEnvContext.reset();
+			PipelineEnvContext.reset(run);
 		}
 	}
 
@@ -188,7 +188,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
 			Thread.currentThread().interrupt();
 		}
 		try {
-			EnvVars pipelineEnvVars = PipelineEnvContext.get();
+			EnvVars pipelineEnvVars = PipelineEnvContext.get(run);
 			jobEnvVars.overrideAll(pipelineEnvVars);
 		} catch (Exception e) {
 			log.error(e);

--- a/src/main/java/io/jenkins/plugins/DingTalkStepListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkStepListener.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins;
 
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.Run;
 import io.jenkins.plugins.context.PipelineEnvContext;
 import lombok.extern.slf4j.Slf4j;
 import org.jenkinsci.plugins.workflow.flow.StepListener;
@@ -15,8 +16,9 @@ public class DingTalkStepListener implements StepListener {
   @Override
   public void notifyOfNewStep(@NonNull Step step, @NonNull StepContext context) {
     try {
+      Run<?, ?> run = context.get(Run.class);
       EnvVars vars = context.get(EnvVars.class);
-      PipelineEnvContext.merge(vars);
+      PipelineEnvContext.merge(run, vars);
     } catch (Exception e) {
       log.error("钉钉插件在获取 pipeline 中的环境变量时异常", e);
     }

--- a/src/main/java/io/jenkins/plugins/context/PipelineEnvAction.java
+++ b/src/main/java/io/jenkins/plugins/context/PipelineEnvAction.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.context;
+
+import hudson.EnvVars;
+import hudson.model.InvisibleAction;
+
+/**
+ * In-memory cache of the pipeline environment collected for a single build.
+ *
+ * <p><strong>{@code vars} must stay {@code transient}.</strong> It accumulates the full environment
+ * of every step, which can include credentials bound by {@code withCredentials}, and Jenkins saves
+ * the build record on its own while the build runs. Were the field serializable, those credentials
+ * would be written to {@code build.xml} in plain text. {@code PipelineEnvActionTest} pins this
+ * down.
+ */
+class PipelineEnvAction extends InvisibleAction {
+
+	private transient EnvVars vars;
+
+	synchronized void merge(EnvVars value) {
+		if (vars == null) {
+			vars = new EnvVars();
+		}
+		vars.overrideAll(value);
+	}
+
+	synchronized EnvVars snapshot() {
+		return vars == null ? new EnvVars() : new EnvVars(vars);
+	}
+}

--- a/src/main/java/io/jenkins/plugins/context/PipelineEnvContext.java
+++ b/src/main/java/io/jenkins/plugins/context/PipelineEnvContext.java
@@ -1,29 +1,62 @@
 package io.jenkins.plugins.context;
 
 import hudson.EnvVars;
+import hudson.model.Run;
 
+/**
+ * Collects the environment variables defined while a pipeline runs, so that they are available
+ * when the notification content is rendered at the end of the build.
+ *
+ * <p>The variables are held on the build itself, in a {@link PipelineEnvAction}, so their lifetime
+ * matches the build's and concurrent builds cannot observe each other's values.
+ */
 public class PipelineEnvContext {
 
-	private static final ThreadLocal<EnvVars> store = new ThreadLocal<>();
-
-	public static void merge(EnvVars value) {
-		if (value == null) {
+	public static void merge(Run<?, ?> run, EnvVars value) {
+		if (run == null || value == null) {
 			return;
 		}
-		EnvVars current = store.get();
-		if (current == null) {
-			store.set(value);
-		} else {
-			current.overrideAll(value);
+		actionFor(run).merge(value);
+	}
+
+	/**
+	 * Returns the cache attached to the build, creating it on demand. {@link Run#save()} locks on
+	 * the build too, and a build is saved repeatedly while it runs, so contend for that lock only
+	 * when the cache still has to be created.
+	 */
+	private static PipelineEnvAction actionFor(Run<?, ?> run) {
+		PipelineEnvAction action = run.getAction(PipelineEnvAction.class);
+		if (action != null) {
+			return action;
+		}
+		synchronized (run) {
+			action = run.getAction(PipelineEnvAction.class);
+			if (action == null) {
+				action = new PipelineEnvAction();
+				run.addAction(action);
+			}
+			return action;
 		}
 	}
 
-	public static EnvVars get() {
-		EnvVars current = store.get();
-		return current == null ? new EnvVars() : current;
+	public static EnvVars get(Run<?, ?> run) {
+		PipelineEnvAction action = run == null ? null : run.getAction(PipelineEnvAction.class);
+		return action == null ? new EnvVars() : action.snapshot();
 	}
 
-	public static void reset() {
-		store.remove();
+	/**
+	 * Drops the cache once the notification has been sent. The build record is saved after
+	 * {@code onCompleted} has run, so removing the action here also keeps it out of the saved build.
+	 */
+	public static void reset(Run<?, ?> run) {
+		if (run == null) {
+			return;
+		}
+		synchronized (run) {
+			PipelineEnvAction action = run.getAction(PipelineEnvAction.class);
+			if (action != null) {
+				run.removeAction(action);
+			}
+		}
 	}
 }

--- a/src/test/java/io/jenkins/plugins/context/PipelineEnvActionTest.java
+++ b/src/test/java/io/jenkins/plugins/context/PipelineEnvActionTest.java
@@ -1,0 +1,78 @@
+package io.jenkins.plugins.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.EnvVars;
+import hudson.util.XStream2;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Test;
+
+class PipelineEnvActionTest {
+
+  @Test
+  void environmentIsNeverPersisted() {
+    // The accumulated environment can include credentials bound by withCredentials, and Jenkins
+    // saves the build record on its own, so none of it may end up in build.xml.
+    PipelineEnvAction action = new PipelineEnvAction();
+    action.merge(new EnvVars("MY_SECRET", "s3cr3t-must-not-be-written"));
+
+    String xml = new XStream2().toXML(action);
+
+    assertFalse(
+        xml.contains("s3cr3t-must-not-be-written"),
+        "credential written to build record: " + xml);
+    assertFalse(xml.contains("MY_SECRET"), "variable name written to build record: " + xml);
+  }
+
+  @Test
+  void environmentFieldStaysTransient() throws Exception {
+    // The assertion above relies on this modifier, and dropping it breaks neither the build nor
+    // any behaviour, so pin it separately.
+    Field field = PipelineEnvAction.class.getDeclaredField("vars");
+    assertTrue(
+        Modifier.isTransient(field.getModifiers()),
+        "vars must stay transient, otherwise credentials are written to build.xml in plain text");
+  }
+
+  @Test
+  void mergeAccumulates() {
+    PipelineEnvAction action = new PipelineEnvAction();
+    action.merge(new EnvVars("A", "1"));
+    action.merge(new EnvVars("B", "2"));
+
+    EnvVars merged = action.snapshot();
+    assertEquals("1", merged.get("A"));
+    assertEquals("2", merged.get("B"));
+  }
+
+  @Test
+  void laterMergeOverridesEarlierValue() {
+    PipelineEnvAction action = new PipelineEnvAction();
+    action.merge(new EnvVars("K", "old"));
+    action.merge(new EnvVars("K", "new"));
+
+    assertEquals("new", action.snapshot().get("K"));
+  }
+
+  @Test
+  void snapshotIsIndependentOfLaterChanges() {
+    // EnvVars extends TreeMap and is not thread safe, so a snapshot handed out must not be
+    // rewritten by a later merge.
+    PipelineEnvAction action = new PipelineEnvAction();
+    action.merge(new EnvVars("K", "v1"));
+    EnvVars snapshot = action.snapshot();
+
+    action.merge(new EnvVars("K", "v2"));
+    snapshot.put("K", "mutated-by-caller");
+
+    assertEquals("v2", action.snapshot().get("K"));
+  }
+
+  @Test
+  void snapshotOfEmptyActionIsEmpty() {
+    assertTrue(new PipelineEnvAction().snapshot().isEmpty());
+  }
+}

--- a/src/test/java/io/jenkins/plugins/context/PipelineEnvContextTest.java
+++ b/src/test/java/io/jenkins/plugins/context/PipelineEnvContextTest.java
@@ -1,0 +1,120 @@
+package io.jenkins.plugins.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.EnvVars;
+import hudson.model.Action;
+import hudson.model.Run;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PipelineEnvContextTest {
+
+  /**
+   * A stand-in for a real {@link Run} that keeps an action list, like {@code Actionable} does.
+   */
+  private static Run<?, ?> fakeRun() {
+    Run<?, ?> run = mock(Run.class);
+    List<Action> actions = new ArrayList<>();
+    doAnswer(invocation -> actions.add(invocation.getArgument(0)))
+        .when(run)
+        .addAction(any(Action.class));
+    doAnswer(invocation -> actions.remove(invocation.<Action>getArgument(0)))
+        .when(run)
+        .removeAction(any(Action.class));
+    when(run.getAction(PipelineEnvAction.class))
+        .thenAnswer(
+            invocation ->
+                actions.stream()
+                    .filter(PipelineEnvAction.class::isInstance)
+                    .findFirst()
+                    .orElse(null));
+    return run;
+  }
+
+  @Test
+  void concurrentRunsAreIsolatedByBuild() {
+    // Reproduces #366: two concurrent builds using the same variable name must not overwrite
+    // each other.
+    Run<?, ?> a = fakeRun();
+    Run<?, ?> b = fakeRun();
+
+    PipelineEnvContext.merge(a, new EnvVars("FOO", "value-a"));
+    PipelineEnvContext.merge(b, new EnvVars("FOO", "value-b"));
+
+    assertEquals("value-a", PipelineEnvContext.get(a).get("FOO"));
+    assertEquals("value-b", PipelineEnvContext.get(b).get("FOO"));
+  }
+
+  @Test
+  void mergeAccumulatesWithinSameBuild() {
+    Run<?, ?> run = fakeRun();
+    PipelineEnvContext.merge(run, new EnvVars("A", "1"));
+    PipelineEnvContext.merge(run, new EnvVars("B", "2"));
+
+    EnvVars merged = PipelineEnvContext.get(run);
+    assertEquals("1", merged.get("A"));
+    assertEquals("2", merged.get("B"));
+  }
+
+  @Test
+  void resetDetachesTheCacheFromTheBuild() {
+    Run<?, ?> run = fakeRun();
+    PipelineEnvContext.merge(run, new EnvVars("K", "v"));
+
+    PipelineEnvContext.reset(run);
+
+    // The action is detached, so it stays out of the build record and the cache is released.
+    assertNull(run.getAction(PipelineEnvAction.class));
+    assertTrue(PipelineEnvContext.get(run).isEmpty());
+  }
+
+  @Test
+  void resetOnlyAffectsTargetBuild() {
+    Run<?, ?> a = fakeRun();
+    Run<?, ?> b = fakeRun();
+    PipelineEnvContext.merge(a, new EnvVars("K", "a"));
+    PipelineEnvContext.merge(b, new EnvVars("K", "b"));
+
+    PipelineEnvContext.reset(a);
+
+    assertTrue(PipelineEnvContext.get(a).isEmpty());
+    assertEquals("b", PipelineEnvContext.get(b).get("K"));
+  }
+
+  @Test
+  void getReturnsDefensiveCopy() {
+    Run<?, ?> run = fakeRun();
+    PipelineEnvContext.merge(run, new EnvVars("K", "original"));
+
+    PipelineEnvContext.get(run).put("K", "mutated");
+
+    assertEquals("original", PipelineEnvContext.get(run).get("K"));
+  }
+
+  @Test
+  void buildWithoutCachedEnvironmentYieldsEmpty() {
+    assertTrue(PipelineEnvContext.get(fakeRun()).isEmpty());
+  }
+
+  @Test
+  void nullRunIsHandledGracefully() {
+    PipelineEnvContext.merge(null, new EnvVars("X", "1"));
+    assertTrue(PipelineEnvContext.get(null).isEmpty());
+    PipelineEnvContext.reset(null);
+  }
+
+  @Test
+  void mergeIgnoresNullValue() {
+    Run<?, ?> run = fakeRun();
+    PipelineEnvContext.merge(run, null);
+    assertTrue(PipelineEnvContext.get(run).isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes #366

Concurrent pipeline builds could lose or overwrite each other's variables in the notification body.

Variables defined while a pipeline runs are collected by `DingTalkStepListener` and were cached in a static `ThreadLocal`. workflow-cps runs pipeline steps on a JVM-wide thread pool (`CpsVmExecutorService`) whose carrier threads are shared and reused across builds: `SingleLaneExecutorService` serialises the tasks of a single build, but it does not pin a thread to that build. A carrier thread that had accumulated one build's variables could therefore later serve another build, whose `overrideAll` merged on top of the leftovers; and a build whose steps ran on one thread could have `onCompleted` read another, finding nothing. `reset()` only cleared the `ThreadLocal` of whichever thread happened to run `onCompleted`, so variables left on the other carrier threads were never released either. With a single build on an idle controller the same thread usually served every step, which is why the feature appeared to work until builds overlapped.

The variables now live in an action on the build itself, so their lifetime matches the build's and concurrent builds cannot reach each other's values. The action is dropped once the notification has been sent, which also keeps it out of the build record.

The collected environment can contain credentials bound by `withCredentials`, so the field holding it is `transient`.

### Testing done

`mvn clean verify` passes: 53 tests, plus spotless, access-modifier-checker, the enforcer import rules and spotbugs (0 findings).

New automated coverage:

- `PipelineEnvContextTest` (8 tests) — the reported scenario, where two builds using the same variable name each keep their own value; `reset` affecting only its own build; accumulation across steps of one build; callers receiving an independent copy; `null` handling.
- `PipelineEnvActionTest` (6 tests) — merge and snapshot semantics, and two guards on the persistence rule: one serialises the action with `XStream2` and asserts neither the variable name nor its value appears, the other asserts the field is still `transient`.

The persistence guards were checked by mutation: dropping the `transient` modifier makes both of them fail, while every other test still passes. This matters because `@XStreamOmitField` is silently ignored here (`XStream2` does not enable annotation processing), so a future change to a "more explicit" annotation would otherwise start writing credentials to `build.xml` unnoticed.

Verified end to end against a local Jenkins 2.516.3 (`mvn hpi:run`). Two robots were configured: one pointing at a local endpoint that records the payloads, one at a real DingTalk webhook. Two pipeline jobs each assigned the same variable name a different value and slept so their builds overlapped, and each job's notification content referenced that variable.

Before, on `main`:

```
JOB=concurrent-a SHARED_VAR=[VALUE-FROM-A]
JOB=concurrent-b SHARED_VAR=[${SHARED_VAR}]    <- b's own value was lost
```

After, on this branch:

```
JOB=concurrent-a SHARED_VAR=[VALUE-FROM-A]
JOB=concurrent-b SHARED_VAR=[VALUE-FROM-B]
```

The saved build records were checked as well: `build.xml` lists only `CauseAction` and workflow-cps' own `EnvActionImpl`, with no trace of this plugin's action nor of the environment it collected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
