### PR TITLE
fix: don't fail notifications when a user has no mobile property

### DIFF
--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -102,7 +102,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
 			User user = User.getById(userIdCause.getUserId(), false);
 			if (user != null) {
 				String name = user.getDisplayName();
-				String mobile = user.getProperty(DingTalkUserProperty.class).getMobile();
+				String mobile = mobileOf(user);
 				if (StringUtils.isEmpty(mobile)) {
 					DingTalkUtils.log(
 							listener,
@@ -116,6 +116,19 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Reads the mobile number a user configured for DingTalk.
+	 *
+	 * <p>{@link User#getProperty} is documented to return null: a user only carries the properties
+	 * that were registered when the user was loaded, and nothing attaches them afterwards. A user
+	 * without this property simply has no mobile number configured, which the caller already
+	 * handles.
+	 */
+	static String mobileOf(User user) {
+		DingTalkUserProperty property = user.getProperty(DingTalkUserProperty.class);
+		return property == null ? null : property.getMobile();
 	}
 
 	private BuildExecutor getExecutorFromRemote(Run<?, ?> run) {

--- a/src/test/java/io/jenkins/plugins/DingTalkRunListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/DingTalkRunListenerTest.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.model.User;
+import org.junit.jupiter.api.Test;
+
+class DingTalkRunListenerTest {
+
+  @Test
+  void mobileIsNullWhenTheUserHasNoDingTalkProperty() {
+    // User#getProperty is documented to return null, and a user that was loaded before this
+    // plugin registered its property carries no DingTalkUserProperty at all.
+    User user = mock(User.class);
+    when(user.getProperty(DingTalkUserProperty.class)).thenReturn(null);
+
+    assertNull(DingTalkRunListener.mobileOf(user));
+  }
+
+  @Test
+  void mobileComesFromTheProperty() {
+    User user = mock(User.class);
+    when(user.getProperty(DingTalkUserProperty.class))
+        .thenReturn(new DingTalkUserProperty("13800000000"));
+
+    assertEquals("13800000000", DingTalkRunListener.mobileOf(user));
+  }
+
+  @Test
+  void mobileIsNullWhenTheUserConfiguredNone() {
+    User user = mock(User.class);
+    when(user.getProperty(DingTalkUserProperty.class)).thenReturn(new DingTalkUserProperty(null));
+
+    assertNull(DingTalkRunListener.mobileOf(user));
+  }
+}


### PR DESCRIPTION
Fixes #303
Fixes #372

Both reports carry the same stack trace:

```
java.lang.NullPointerException: Cannot invoke "io.jenkins.plugins.DingTalkUserProperty.getMobile()"
  because the return value of "hudson.model.User.getProperty(java.lang.Class)" is null
```

`getExecutorFromUser` read the mobile number straight off `user.getProperty(DingTalkUserProperty.class)`. That method is documented as "Gets the specific property, or null": a user carries only the properties that were registered when the user was loaded (`User#load` -> `allocateDefaultPropertyInstancesAsNeeded`), and nothing attaches them to an already-cached user afterwards. Jenkins core itself treats the result as nullable — see `ApiTokenProperty`, which checks for null and recreates the property.

The throw happens whenever a build is started manually, since that is the only case with a `UserIdCause`, and it costs the whole notification: `onStarted` has no try/catch, so the exception escapes and the start notification is lost, while `onCompleted` catches it and logs "发送消息时报错" instead of notifying. This is not specific to freestyle jobs; a manually started pipeline hits it too.

A user without the property simply has no mobile number configured, which the rest of the code already handles: the empty-mobile branch logs the hint to add one, `EXECUTOR_MOBILE` falls back to an empty string, and the executor's mobile is only appended to the @-list when it is non-empty. So the guard restores the behaviour the surrounding code was already written for.

### Testing done

`mvn clean verify` passes: 56 tests, plus spotless, access-modifier-checker, the enforcer import rules and spotbugs (0 findings).

`DingTalkRunListenerTest` covers the lookup: no property at all, a property carrying a number, and a property with none configured.

The first of those was checked by mutation — restoring the unguarded `user.getProperty(...).getMobile()` makes it fail with exactly the stack trace quoted above, so the test reproduces the reported failure rather than merely exercising the line.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
