### PR TITLE
fix: log the payload that is actually sent to DingTalk

### DIFF
--- a/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
+++ b/src/main/java/io/jenkins/plugins/DingTalkRunListener.java
@@ -292,7 +292,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
 
 			String robotId = item.getRobotId();
 			String content = item.getContent();
-			String message = item.getMessage();
+			String rawMessage = item.getMessage();
 			boolean atAll = item.isAtAll();
 			Set<String> atMobiles = item.resolveAtMobiles(envVars);
 
@@ -306,7 +306,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
                     ? MessageModel.builder()
                             .type(MsgTypeEnum.MARKDOWN)
                             .title(title)
-                            .text(envVars.expand(message).replace("\\\\n", "\n"))
+                            .text(envVars.expand(rawMessage).replace("\\\\n", "\n"))
                             .build()
                     : MessageModel.builder()
                             .type(MsgTypeEnum.ACTION_CARD)
@@ -329,7 +329,7 @@ public class DingTalkRunListener extends RunListener<Run<?, ?>> {
                             .build();
 
 			DingTalkUtils.log(listener, "当前机器人信息，%s", Utils.toJson(item));
-			DingTalkUtils.log(listener, "发送的消息详情，%s", Utils.toJson(message));
+			DingTalkUtils.log(listener, "发送的消息详情，%s", Utils.toJson(msgModel));
 
 			String msg = DingTalkService.getInstance().send(robotId, msgModel);
 

--- a/src/test/java/io/jenkins/plugins/DingTalkRunListenerLogTest.java
+++ b/src/test/java/io/jenkins/plugins/DingTalkRunListenerLogTest.java
@@ -1,0 +1,99 @@
+package io.jenkins.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.enums.NoticeOccasionEnum;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers the "发送的消息详情" line of the build log, which is the only place a user can see what the
+ * plugin actually posted to DingTalk.
+ */
+@WithJenkins
+class DingTalkRunListenerLogTest {
+
+  /** A robot pointing at a closed port: sending fails, which the listener logs and moves on. */
+  private static final String UNREACHABLE = "http://127.0.0.1:1/robot/send?access_token=none";
+
+  private static final String ROBOT_ID = "robot-under-test";
+
+  /**
+   * Expanded by {@code DingTalkRunListener} into the project name, so finding it in the log proves
+   * the logged object is the expanded payload rather than the raw template.
+   */
+  private static final String TEMPLATE = "payload-marker ${PROJECT_NAME}";
+
+  private static void registerRobot(JenkinsRule r) {
+    ArrayList<DingTalkRobotConfig> robots = new ArrayList<>();
+    robots.add(new DingTalkRobotConfig(ROBOT_ID, "robot under test", UNREACHABLE, new ArrayList<>()));
+    DingTalkGlobalConfig config = DingTalkGlobalConfig.getInstance();
+    config.setRobotConfigs(robots);
+    // Every DingTalkUtils.log call is gated on this, so the diagnostic lines only reach the build
+    // log once a user turns verbose logging on — which is exactly when they are diagnosing.
+    config.setVerbose(true);
+  }
+
+  private static FreeStyleProject jobNotifying(JenkinsRule r, String name, boolean raw)
+      throws Exception {
+    DingTalkNotifierConfig notifier = new DingTalkNotifierConfig(
+        raw,
+        false,
+        true,
+        ROBOT_ID,
+        "robot under test",
+        false,
+        null,
+        raw ? null : TEMPLATE,
+        raw ? TEMPLATE : null,
+        // Not Set.of(): JEP-200 class filtering allows ImmutableCollections$List12/ListN but has
+        // no Set or Map counterpart, so saving the job config would fail.
+        new HashSet<>(List.of(NoticeOccasionEnum.SUCCESS.name())));
+    ArrayList<DingTalkNotifierConfig> notifiers = new ArrayList<>();
+    notifiers.add(notifier);
+
+    FreeStyleProject job = r.createFreeStyleProject(name);
+    job.addProperty(new DingTalkJobProperty(notifiers));
+    return job;
+  }
+
+  @Test
+  void logsTheBuiltInPayloadInsteadOfNull(JenkinsRule r) throws Exception {
+    registerRobot(r);
+    FreeStyleProject job = jobNotifying(r, "built-in-notification", false);
+
+    FreeStyleBuild build = r.buildAndAssertSuccess(job);
+    String log = r.getLog(build);
+
+    // A built-in notification leaves the raw-template field unset, so logging that field printed
+    // literally "null" for every build since the raw mode was added.
+    assertFalse(log.contains("发送的消息详情，null"), () -> "still logging the wrong field:\n" + log);
+    assertTrue(log.contains("ACTION_CARD"), () -> "message type missing from the log:\n" + log);
+    assertTrue(
+        log.contains("payload-marker built-in-notification"),
+        () -> "logged text is not the expanded payload:\n" + log);
+  }
+
+  @Test
+  void logsTheExpandedRawPayloadInsteadOfTheTemplate(JenkinsRule r) throws Exception {
+    registerRobot(r);
+    FreeStyleProject job = jobNotifying(r, "raw-notification", true);
+
+    FreeStyleBuild build = r.buildAndAssertSuccess(job);
+    String log = r.getLog(build);
+
+    assertTrue(log.contains("MARKDOWN"), () -> "message type missing from the log:\n" + log);
+    // The unexpanded template is already visible on the preceding "当前机器人信息" line, so only the
+    // expanded form distinguishes the payload from the configuration.
+    assertTrue(
+        log.contains("payload-marker raw-notification"),
+        () -> "logged text is not the expanded payload:\n" + log);
+  }
+}


### PR DESCRIPTION
### What this fixes

The `发送的消息详情` (message details) line of the build log is the only place a user can see what the plugin actually posted to DingTalk. It has been logging the wrong object since the raw notification mode was added in `c66a0df` (2023-03).

Before that commit, the local variable `message` **was** the `MessageModel`, and the log line was correct. `c66a0df` needed a variable for the user's custom template and reused the same name for it, renaming the model to `msgModel`. Two call sites had to follow, and only one of them did:

```java
String message = item.getMessage();                 // new: the raw template
MessageModel msgModel = item.isRaw() ? ... : ...;   // renamed: the payload

DingTalkUtils.log(listener, "发送的消息详情，%s", Utils.toJson(message));   // silently kept the old name
String msg = service.send(robotId, msgModel);                             // had to be updated
```

`send(String, MessageModel)` rejected a `String`, so the compiler forced that one. `Utils.toJson(Object)` accepted it, so the log line kept compiling with entirely different meaning. The result:

- a **built-in** notification logs literally `发送的消息详情，null`, because the template field is unset when the built-in message is used;
- a **raw** notification logs the template *before* variable expansion, not what was sent.

Every `DingTalkUtils.log` call is gated on the global verbose setting, so this line only reaches the build log once someone turns detailed logging on — which is exactly when they are trying to diagnose a delivery problem and get `null` instead.

Nothing is lost by pointing it at the payload: the preceding `当前机器人信息` line already logs the notifier configuration, raw template included.

The local variable is renamed to `rawMessage` in the same change. That is what removes the trap rather than just its symptom: there is no longer a `message` in this scope for a future rename to collide with.

### Testing done

`mvn clean verify` passes: 58 tests, plus spotless, access-modifier-checker, the enforcer import rules and spotbugs (0 findings).

`DingTalkRunListenerLogTest` runs a real build through `JenkinsRule` against a robot pointing at a closed port, then asserts on the build log — one case for the built-in message, one for a raw template. Both assert the log carries the *expanded* payload, which is what distinguishes it from the configuration line above it.

Both cases were checked by mutation: restoring `Utils.toJson(message)` makes them fail with `[钉钉插件]发送的消息详情，null` in the captured log, so they reproduce the reported behaviour rather than merely exercising the line.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
