### PR TITLE
fix: show the textarea the saved notifier configuration actually uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@
 ## Lessons Learned (Jelly & Jenkins UI)
 - Avoid XML-unsafe operators in Jelly expressions (`&&`); use `and` to prevent SAX parse failures.
 - When embedding a config.jelly inside a `f:repeatable`, the current item may be exposed as `item`; set `instance` explicitly if the sub-view expects it.
-- `f:hetero-list` requires a non-null descriptor list; for data-bound lists prefer `f:repeatableHeteroProperty` or provide an explicit `*Descriptors` getter that matches the `field` name (`<field>Descriptors`).
+- `f:hetero-list` keys items by descriptor — one prototype per descriptor, and `oneEach` caps the list at that count — so it cannot express one item per instance of a single descriptor. `DingTalkRobotConfig/config.jelly` uses it as intended for the security policies; `DingTalkJobProperty/config.jelly` cannot, and renders the hetero-list item structure itself with robot ids where the tag puts descriptor ids — keep that copy in step with `lib/form/hetero-list`.
+- For ordinary data-bound lists use `f:repeatableHeteroProperty`, or give `f:hetero-list` an explicit `<field>Descriptors` getter.
 - If the view can be rendered under a global descriptor context, ensure descriptor getters exist on that context too, or access the descriptor directly via `it`.
 - `renderOnDemand` requires the `l` namespace; missing it causes parse errors. Use it only when needed to avoid `$stapler/bound/.../render` failures.
 - Avoid `j:new` with plugin classes in views; class loading can fail in runtime. Prefer descriptor-backed prototypes and standard `f:*` tags.

--- a/src/main/resources/io/jenkins/plugins/DingTalkJobProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/DingTalkJobProperty/config.jelly
@@ -14,10 +14,21 @@
     value="${instance.getCheckedNotifierConfigs()}"/>
 
   <d:taglib uri="local">
+    <!-- Mirrors the per-item structure of lib/form/hetero-list, which this view has to render
+         itself: its items are one per robot rather than one per descriptor, which the tag cannot
+         express. The drag handle is left out on purpose — the order here comes from the global
+         robot list, so it is not the job's to rearrange. -->
     <d:tag name="body">
-        <f:repeatableDeleteButton/>
+        <div class="repeated-chunk__header repeated-chunk__header--no-handle">
+            ${attrs.title}
+            <j:if test="${!readOnlyMode}">
+                <f:repeatableDeleteButton/>
+            </j:if>
+        </div>
         <f:class-entry descriptor="${descriptor}"/>
-        <d:invokeBody/>
+        <div class="jenkins-repeated-chunk__content">
+            <d:invokeBody/>
+        </div>
     </d:tag>
   </d:taglib>
 

--- a/src/main/resources/io/jenkins/plugins/DingTalkNotifierConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/DingTalkNotifierConfig/config.jelly
@@ -6,50 +6,48 @@
 			src="${rootURL}/plugin/dingding-notifications/scripts/notifierConfig.js"/>
 	</st:once>
 
-	<f:entry title="${instance.getRobotName()}" class="">
-		<f:advanced>
-			<f:entry title="${%disable}" field="disabled">
-				<f:checkbox checked="${instance.getDisabled()}"/>
+	<f:advanced>
+		<f:entry title="${%disable}" field="disabled">
+			<f:checkbox checked="${instance.getDisabled()}"/>
+		</f:entry>
+		<f:entry title="${%disableBuiltIn}" field="raw">
+			<f:checkbox checked="${instance.getRaw()}" class="dt-notifier-config-raw"/>
+		</f:entry>
+		<f:entry title="${%noticeOccasion}" field="noticeOccasions">
+			<table class="jenkins-table">
+				<tbody>
+					<j:forEach var="row" items="${descriptor.noticeOccasionRows}">
+						<tr>
+							<j:forEach var="option" items="${row}">
+								<td>
+									<f:checkbox
+										json="${option.name}"
+										name="noticeOccasions"
+										checked="${instance.noticeOccasions.contains(option.name)}"
+										title="${option.label}"
+									/>
+								</td>
+							</j:forEach>
+						</tr>
+					</j:forEach>
+				</tbody>
+			</table>
+		</f:entry>
+		<f:entry title="${%notifyPeople}" field="at">
+			<f:checkbox title="${%atAll}" field="atAll"/>
+			<f:textarea field="atMobile"/>
+		</f:entry>
+		<div class="dt-raw-content-custom" style="display: none;">
+			<f:entry field="message" title="${%customMessage}">
+				<f:textarea/>
 			</f:entry>
-			<f:entry title="${%disableBuiltIn}" field="raw">
-				<f:checkbox checked="${instance.getRaw()}" class="dt-notifier-config-raw"/>
+		</div>
+		<div class="dt-raw-content-builtin">
+			<f:entry field="content" title="${%customContent}">
+				<f:textarea/>
 			</f:entry>
-			<f:entry title="${%noticeOccasion}" field="noticeOccasions">
-				<table class="jenkins-table">
-					<tbody>
-						<j:forEach var="row" items="${descriptor.noticeOccasionRows}">
-							<tr>
-								<j:forEach var="option" items="${row}">
-									<td>
-										<f:checkbox
-											json="${option.name}"
-											name="noticeOccasions"
-											checked="${instance.noticeOccasions.contains(option.name)}"
-											title="${option.label}"
-										/>
-									</td>
-								</j:forEach>
-							</tr>
-						</j:forEach>
-					</tbody>
-				</table>
-			</f:entry>
-			<f:entry title="${%notifyPeople}" field="at">
-				<f:checkbox title="${%atAll}" field="atAll"/>
-				<f:textarea field="atMobile"/>
-			</f:entry>
-			<div class="dt-raw-content-custom" style="display: none;">
-				<f:entry field="message" title="${%customMessage}">
-					<f:textarea/>
-				</f:entry>
-			</div>
-			<div class="dt-raw-content-builtin">
-				<f:entry field="content" title="${%customContent}">
-					<f:textarea/>
-				</f:entry>
-			</div>
-		</f:advanced>
-	</f:entry>
+		</div>
+	</f:advanced>
 	<f:invisibleEntry>
 		<input type="hidden" name="robotId" value="${instance.getRobotId()}"/>
 	</f:invisibleEntry>

--- a/src/main/webapp/scripts/notifierConfig.js
+++ b/src/main/webapp/scripts/notifierConfig.js
@@ -1,11 +1,25 @@
 Behaviour.specify('.dt-notifier-config-raw', 'dt-notifier-config-raw', 0, function (element) {
-    element.onchange = function () {
-        if (element.checked) {
-            document.querySelector('.dt-raw-content-builtin').style.display = 'none'
-            document.querySelector('.dt-raw-content-custom').style.display = ''
-        } else {
-            document.querySelector('.dt-raw-content-builtin').style.display = ''
-            document.querySelector('.dt-raw-content-custom').style.display = 'none'
-        }
+    // Every configured robot renders this same markup, so the blocks have to be resolved within
+    // the notifier this checkbox belongs to rather than document-wide. Both paths that produce a
+    // notifier put it in its own `repeated-chunk`: the job property's view for the ones already
+    // saved, and the hetero-list script for the ones added afterwards, which sets the class
+    // before applying behaviours to the new subtree.
+    var scope = element.closest('.repeated-chunk')
+    var builtin = scope && scope.querySelector('.dt-raw-content-builtin')
+    var custom = scope && scope.querySelector('.dt-raw-content-custom')
+    if (!builtin || !custom) {
+        return
     }
+
+    function apply() {
+        builtin.style.display = element.checked ? 'none' : ''
+        custom.style.display = element.checked ? '' : 'none'
+    }
+
+    // Behaviour.specify invokes this once per matching element as the form renders, which is the
+    // only chance to show the block that the saved configuration actually uses. Without it the
+    // view's own default wins and a notifier saved with the built-in message disabled comes back
+    // offering the textarea it no longer sends, so edits land in a field nothing reads.
+    apply()
+    element.onchange = apply
 })

--- a/src/test/java/io/jenkins/plugins/DingTalkJobPropertyFormTest.java
+++ b/src/test/java/io/jenkins/plugins/DingTalkJobPropertyFormTest.java
@@ -1,0 +1,136 @@
+package io.jenkins.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.enums.NoticeOccasionEnum;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers the job configuration form round-tripping the notifier list.
+ *
+ * <p>This view renders the per-item structure of lib/form/hetero-list itself, so the names and
+ * classes the hetero-list script and the form submission rely on are this plugin's to keep right.
+ * Saving the page unchanged has to give back what was there, and the header the list is drawn with
+ * has to name the robot, since that is the only thing distinguishing one item from another.
+ */
+@WithJenkins
+class DingTalkJobPropertyFormTest {
+
+  private static FreeStyleProject jobWithTwoRobots(JenkinsRule r) throws Exception {
+    ArrayList<DingTalkRobotConfig> robots = new ArrayList<>();
+    robots.add(new DingTalkRobotConfig("robot-a", "RobotA", "http://127.0.0.1:1/a", new ArrayList<>()));
+    robots.add(new DingTalkRobotConfig("robot-b", "RobotB", "http://127.0.0.1:1/b", new ArrayList<>()));
+    DingTalkGlobalConfig.getInstance().setRobotConfigs(robots);
+
+    ArrayList<DingTalkNotifierConfig> notifiers = new ArrayList<>();
+    // The two differ in every field the form round-trips, so a value going missing cannot be
+    // masked by the other notifier's copy of it.
+    notifiers.add(notifier("robot-a", "RobotA", false, false, NoticeOccasionEnum.UNSTABLE));
+    notifiers.add(notifier("robot-b", "RobotB", true, true, NoticeOccasionEnum.SUCCESS,
+        NoticeOccasionEnum.FAILURE));
+
+    FreeStyleProject job = r.createFreeStyleProject("round-trip");
+    job.addProperty(new DingTalkJobProperty(notifiers));
+    return job;
+  }
+
+  private static DingTalkNotifierConfig notifier(
+      String id, String name, boolean raw, boolean disabled, NoticeOccasionEnum... occasions) {
+    Set<String> names = new HashSet<>();
+    for (NoticeOccasionEnum occasion : occasions) {
+      // Not Set.of(): JEP-200 class filtering allows ImmutableCollections$List12/ListN but has
+      // no Set or Map counterpart, so saving the job config would fail.
+      names.add(occasion.name());
+    }
+    return new DingTalkNotifierConfig(
+        raw, disabled, true, id, name, false, "13800138000",
+        "content of " + name, "message of " + name, names);
+  }
+
+  private static DingTalkNotifierConfig find(List<DingTalkNotifierConfig> all, String name) {
+    return all.stream()
+        .filter(n -> name.equals(n.getRobotName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no notifier for " + name));
+  }
+
+  private static JenkinsRule.WebClient client(JenkinsRule r) {
+    JenkinsRule.WebClient wc = r.createWebClient();
+    wc.getOptions().setThrowExceptionOnScriptError(false);
+    wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+    return wc;
+  }
+
+  @Test
+  void namesEachRobotInItsOwnChunkHeader(JenkinsRule r) throws Exception {
+    HtmlPage page = client(r).getPage(jobWithTwoRobots(r), "configure");
+
+    List<String> headers = new ArrayList<>();
+    page.querySelectorAll("div.repeated-chunk[name=notifierConfigs] .repeated-chunk__header")
+        .forEach(node -> headers.add(node.asNormalizedText().trim()));
+
+    assertEquals(2, headers.size(), "one header per configured robot");
+    assertTrue(headers.get(0).startsWith("RobotA"), "header names the robot, got: " + headers.get(0));
+    assertTrue(headers.get(1).startsWith("RobotB"), "header names the robot, got: " + headers.get(1));
+
+    assertEquals(
+        2,
+        page.querySelectorAll(
+                "div.repeated-chunk[name=notifierConfigs] .jenkins-repeated-chunk__content")
+            .size(),
+        "each chunk wraps its body the way lib/form/hetero-list does");
+  }
+
+  @Test
+  void savingTheFormUnchangedKeepsEveryNotifier(JenkinsRule r) throws Exception {
+    FreeStyleProject job = jobWithTwoRobots(r);
+    JenkinsRule.WebClient wc = client(r);
+    HtmlForm form = wc.getPage(job, "configure").getFormByName("config");
+    r.submit(form);
+
+    DingTalkJobProperty saved = job.getProperty(DingTalkJobProperty.class);
+    assertNotNull(saved, "the property survives a save");
+
+    List<DingTalkNotifierConfig> notifiers = saved.getCheckedNotifierConfigs();
+    assertEquals(2, notifiers.size(), "both robots are still selected after saving");
+
+    for (DingTalkNotifierConfig notifier : notifiers) {
+      String name = notifier.getRobotName();
+      assertEquals("content of " + name, notifier.getContent(), name + " keeps its custom content");
+      assertEquals("message of " + name, notifier.getMessage(), name + " keeps its custom message");
+      assertEquals("13800138000", notifier.getAtMobile(), name + " keeps its mentions");
+      assertTrue(notifier.isChecked(), name + " stays selected");
+    }
+
+    DingTalkNotifierConfig a = find(notifiers, "RobotA");
+    DingTalkNotifierConfig b = find(notifiers, "RobotB");
+
+    assertFalse(a.isRaw(), "RobotA keeps the built-in message");
+    assertTrue(b.isRaw(), "RobotB keeps it disabled");
+    assertFalse(a.isDisabled(), "RobotA stays enabled");
+    assertTrue(b.isDisabled(), "RobotB stays disabled");
+
+    // getNoticeOccasions() falls back to the global default, which is every occasion, so a set
+    // that went missing would come back as all six rather than as null.
+    assertEquals(
+        new HashSet<>(List.of(NoticeOccasionEnum.UNSTABLE.name())),
+        a.getNoticeOccasions(),
+        "RobotA keeps the single occasion it was saved with");
+    assertEquals(
+        new HashSet<>(List.of(NoticeOccasionEnum.SUCCESS.name(), NoticeOccasionEnum.FAILURE.name())),
+        b.getNoticeOccasions(),
+        "RobotB keeps the two occasions it was saved with");
+  }
+}

--- a/src/test/java/io/jenkins/plugins/DingTalkNotifierConfigFormTest.java
+++ b/src/test/java/io/jenkins/plugins/DingTalkNotifierConfigFormTest.java
@@ -1,0 +1,160 @@
+package io.jenkins.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.enums.NoticeOccasionEnum;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.HtmlCheckBoxInput;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers which message textarea the job configuration form offers.
+ *
+ * <p>A notifier saved with the built-in message disabled sends `自定义消息` and nothing else, so that
+ * is the block the form has to show; offering the other one sends edits to a field nothing reads.
+ * Two robots are configured throughout because the blocks used to be looked up document-wide,
+ * which only misbehaves once the markup is on the page more than once.
+ *
+ * <p>Both cases start from robots that are already part of the job. A notifier added through the
+ * "add robot" menu takes the same path — the hetero-list script applies behaviours to the subtree it
+ * inserts — but that menu is a dropdown these tests cannot open, so that half is covered by hand.
+ */
+@WithJenkins
+class DingTalkNotifierConfigFormTest {
+
+  private static final String BUILT_IN = "robot-built-in";
+  private static final String RAW = "robot-raw";
+
+  private static FreeStyleProject jobWithBothModes(JenkinsRule r) throws Exception {
+    ArrayList<DingTalkRobotConfig> robots = new ArrayList<>();
+    robots.add(new DingTalkRobotConfig(BUILT_IN, "BuiltIn", "http://127.0.0.1:1/a", new ArrayList<>()));
+    robots.add(new DingTalkRobotConfig(RAW, "Raw", "http://127.0.0.1:1/b", new ArrayList<>()));
+    DingTalkGlobalConfig.getInstance().setRobotConfigs(robots);
+
+    ArrayList<DingTalkNotifierConfig> notifiers = new ArrayList<>();
+    notifiers.add(notifier(BUILT_IN, "BuiltIn", false));
+    notifiers.add(notifier(RAW, "Raw", true));
+
+    FreeStyleProject job = r.createFreeStyleProject("form-under-test");
+    job.addProperty(new DingTalkJobProperty(notifiers));
+    return job;
+  }
+
+  private static DingTalkNotifierConfig notifier(String id, String name, boolean raw) {
+    return new DingTalkNotifierConfig(
+        raw,
+        false,
+        true,
+        id,
+        name,
+        false,
+        "",
+        "content of " + name,
+        "message of " + name,
+        // Not Set.of(): JEP-200 class filtering allows ImmutableCollections$List12/ListN but has
+        // no Set or Map counterpart, so saving the job config would fail.
+        new HashSet<>(List.of(NoticeOccasionEnum.SUCCESS.name())));
+  }
+
+  /** The notifier a block belongs to is identified by the content its textarea was saved with. */
+  private static DomElement blockHolding(HtmlPage page, String text) {
+    for (DomNode node : page.querySelectorAll(".dt-raw-content-builtin, .dt-raw-content-custom")) {
+      DomElement block = (DomElement) node;
+      if (block.asXml().contains(text)) {
+        return block;
+      }
+    }
+    throw new AssertionError("no notifier block holds " + text);
+  }
+
+  private static boolean hidden(DomElement block) {
+    return block.getAttribute("style").replace(" ", "").contains("display:none");
+  }
+
+  private static HtmlPage configurePage(JenkinsRule r, FreeStyleProject job) throws Exception {
+    JenkinsRule.WebClient wc = r.createWebClient();
+    wc.getOptions().setJavaScriptEnabled(true);
+    wc.getOptions().setThrowExceptionOnScriptError(false);
+    wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+    HtmlPage page = wc.getPage(job, "configure");
+    wc.waitForBackgroundJavaScript(2000);
+    return page;
+  }
+
+  @Test
+  void offersTheBlockEachSavedNotifierActuallySends(JenkinsRule r) throws Exception {
+    HtmlPage page = configurePage(r, jobWithBothModes(r));
+
+    assertEquals(2, page.querySelectorAll(".dt-notifier-config-raw").size(), "both robots render");
+
+    assertFalse(
+        hidden(blockHolding(page, "content of BuiltIn")),
+        "the notifier keeping the built-in message must offer 自定义内容");
+    assertTrue(
+        hidden(blockHolding(page, "message of BuiltIn")),
+        "the notifier keeping the built-in message must not offer 自定义消息");
+
+    assertFalse(
+        hidden(blockHolding(page, "message of Raw")),
+        "a notifier saved with the built-in message disabled must offer 自定义消息, since that is "
+            + "the only field it sends");
+    assertTrue(
+        hidden(blockHolding(page, "content of Raw")),
+        "a notifier saved with the built-in message disabled must not offer 自定义内容");
+  }
+
+  @Test
+  void togglingOneNotifierLeavesTheOtherAlone(JenkinsRule r) throws Exception {
+    // Both saved keeping the built-in message, then the *second* one is ticked. The direction
+    // matters: unticking moves a notifier towards the markup's own default, so looking the block
+    // up document-wide happens to land on the same result and proves nothing. Ticking the second
+    // notifier is the transition where addressing the wrong notifier becomes visible.
+    HtmlPage page = configurePage(r, jobWithNeitherRaw(r));
+
+    List<DomNode> boxes = page.querySelectorAll(".dt-notifier-config-raw");
+    assertEquals(2, boxes.size(), "both robots render");
+    HtmlCheckBoxInput second = (HtmlCheckBoxInput) boxes.get(1);
+    assertFalse(second.isChecked(), "the second notifier starts out keeping the built-in message");
+
+    second.setChecked(true);
+
+    assertTrue(
+        hidden(blockHolding(page, "content of Second")),
+        "ticking the second notifier must hide its own 自定义内容");
+    assertFalse(
+        hidden(blockHolding(page, "message of Second")),
+        "ticking the second notifier must reveal its own 自定义消息");
+
+    assertFalse(
+        hidden(blockHolding(page, "content of First")),
+        "the first notifier must be left alone");
+    assertTrue(
+        hidden(blockHolding(page, "message of First")),
+        "the first notifier must be left alone");
+  }
+
+  private static FreeStyleProject jobWithNeitherRaw(JenkinsRule r) throws Exception {
+    ArrayList<DingTalkRobotConfig> robots = new ArrayList<>();
+    robots.add(new DingTalkRobotConfig("robot-first", "First", "http://127.0.0.1:1/a", new ArrayList<>()));
+    robots.add(new DingTalkRobotConfig("robot-second", "Second", "http://127.0.0.1:1/b", new ArrayList<>()));
+    DingTalkGlobalConfig.getInstance().setRobotConfigs(robots);
+
+    ArrayList<DingTalkNotifierConfig> notifiers = new ArrayList<>();
+    notifiers.add(notifier("robot-first", "First", false));
+    notifiers.add(notifier("robot-second", "Second", false));
+
+    FreeStyleProject job = r.createFreeStyleProject("toggle-under-test");
+    job.addProperty(new DingTalkJobProperty(notifiers));
+    return job;
+  }
+}


### PR DESCRIPTION
Fixes #369

A notifier has two textareas that both take message content, and which one is sent depends on the "disable built-in message" checkbox: unchecked sends the built-in message with `自定义内容` appended, checked sends `自定义消息` and nothing else. The form is supposed to show whichever one applies and hide the other. It showed the wrong one, in two different ways.

### The reporter's log says it all

```json
{"raw":true, "content":"## <font color=green>APP意见反馈接口测试</font> ...", "message":""}
```

Their markdown went into `自定义内容`, but `raw: true` sends `自定义消息`, which was empty — so the request went out with a blank markdown text and DingTalk answered `400403 参数 markdown --》 text 缺失`.

They had not misconfigured anything. The form offered them the textarea that mode does not send.

### Two defects

**The saved value was never read back.** The view hardcodes `display: none` on the custom block and the script only assigned styles from `onchange`, so every render offered `自定义内容` and hid `自定义消息` however the notifier had been saved. Reopening a notifier saved with the built-in message disabled therefore presented the field it no longer sends, and edits made there landed where nothing reads them.

**The handler addressed the wrong notifier.** It reached for its blocks with `document.querySelector`, which returns the first match in the document rather than the one belonging to the checkbox that changed. Every configured robot renders this same markup, so with more than one robot the second robot's checkbox toggled the first robot's textareas and left its own alone — the checkbox did nothing observable at all.

### How it got here

#239 reported the visible half of this in 2024 and was closed by #240, which replaced `window.addEventListener('load')` plus a single `querySelector` with `Behaviour.specify` so that every checkbox gets a handler. That part was right, but both `document.querySelector` calls moved into the new callback unchanged, and the initial render was never part of it.

Before either of them, the de-jQuery-ification in `70215a4` had translated `$('.x').css(…)`, which applies to **every** match, into `document.querySelector('.x').style`, which applies to the **first**. That is where addressing the wrong notifier came from — with a single robot configured, as in development, all three versions look identical, which is why it survived three years.

### The fix

`Behaviour.specify` invokes its callback once per matching element as the form renders, which is exactly where the saved state has to be applied, so the same function now serves both the first paint and later changes. The blocks are resolved with `closest('.repeated-chunk')` — the container core itself reaches for the same way, in `hetero-list.js` and in the help-area lookup in `hudson-behavior.js`.

### Why the surrounding markup moves too

This view renders the per-item structure of `lib/form/hetero-list` itself rather than using the tag, and the fix depends on that structure, so it is worth saying why: its items are one per robot, all sharing one descriptor. The tag builds one prototype per descriptor and `oneEach` caps the list at that count, so through the tag a job could configure exactly one robot, listed under the descriptor's class name rather than the robot's.

That hand-rolled copy had drifted, missing the header and content structure core has since grown, so the notifier name sat as loose text where every other list on the page shows a styled header. Both are ported here. The drag handle deliberately is not: the order comes from the global robot list, so it is not the job's to rearrange.

| | before | after |
|---|---|---|
| chunk header | none; robot name as plain text inside the body | `repeated-chunk__header--no-handle`, naming the robot |
| chunk body | direct children of `.repeated-chunk` | wrapped in `jenkins-repeated-chunk__content` |

The empty `f:entry` that used to carry the robot name goes with it, which is also how core writes this — all eight `f:advanced` usages in core sit beside `f:entry`, never inside one, and the tag already emits its own `.jenkins-form-item`.

### Tests

Four cases, all against a real job configuration page with two robots.

| test | what it pins |
|---|---|
| `offersTheBlockEachSavedNotifierActuallySends` | each saved notifier is offered the block it actually sends |
| `togglingOneNotifierLeavesTheOtherAlone` | ticking the second notifier moves its own blocks and leaves the first one's alone |
| `namesEachRobotInItsOwnChunkHeader` | each chunk's header names its robot, and the body is wrapped the way core's tag wraps it |
| `savingTheFormUnchangedKeepsEveryNotifier` | saving unchanged returns every notifier with its content, message, mentions, mode, enabled state and notice occasions |

The first two fail against the previous script. The second one ticks rather than unticks deliberately: unticking moves a notifier towards the markup's own default, so looking the block up document-wide lands on the same result and the test passes while the bug is present. Removing the initial call fails only the first case and dropping the `onchange` assignment fails only the second, so neither case stands in for the other.

The round-trip case seeds the two notifiers with different values in every field, because `getNoticeOccasions()` falls back to the global default — a set that went missing would come back as all six occasions rather than as null, and identical seeds would hide that.

One path is not covered: a notifier added through the "add robot" menu takes the same route, since the hetero-list script applies behaviours to the subtree it inserts, but that menu is a dropdown the test client cannot open. That half was checked by hand and it is noted in the test's javadoc.

### Not addressed here

There is extra space under the `Advanced` button in these chunks, and it changes after the section is expanded and collapsed. That is core's: `jenkins-repeated-chunk__content > *:last-of-type { margin-bottom: 0 }` keys the trailing margin on `:last-of-type`, which counts `display: none` siblings of the same tag, and `advanced.js` permanently moves the advanced rows to sit after that block. Core's own `Execute shell` chunk behaves identically. Working around it in this plugin would only pin our markup order to a core selector that is likely to change, so it is left alone.
